### PR TITLE
docs: move customization and contributing sections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Customization and Contributing
+
+## Customization
+
+### Adding New Tools
+
+Edit the OS-specific installer(s):
+
+- On macOS: update `os/macos/install.sh` (add to the `tools` list or `apps` list)
+- On Linux: update `os/linux/install.sh` (check `install_cli_tools` function)
+
+### Modifying Dotfiles
+
+All dotfiles are located in the `dotfiles/` directory:
+
+- `dotfiles/.vimrc` - Vim configuration
+- `dotfiles/.tmux.conf` - Tmux configuration
+- `dotfiles/.zshrc` - Zsh configuration
+- `dotfiles/.gitconfig` - Git configuration
+- `dotfiles/functions.sh` - Shared utility functions
+- `dotfiles/aliases.sh` - Shared aliases
+
+After modifying, re-run the installer or create symlinks manually:
+
+```bash
+ln -sf ~/.dotfiles/dotfiles/.vimrc ~/.vimrc
+```
+
+### Adding OS Support
+
+To add support for other operating systems:
+
+1. Create a new directory: `os/[osname]/`
+2. Add an `install.sh` script following existing examples
+3. The main installer will automatically detect and use it
+
+Example structure:
+
+```text
+os/
+├── macos/
+│   ├── install.sh
+└── linux/
+    ├── install.sh
+```
+
+## Contributing
+
+Feel free to submit issues and enhancement requests! This dotfiles setup is designed to be:
+
+- **Modular** - Easy to add/remove components
+- **Cross-platform** - Built for easy OS support addition
+- **Configurable** - Simple to customize for personal preferences
+

--- a/README.md
+++ b/README.md
@@ -182,49 +182,7 @@ Linux only:
 - Useful functions for productivity and development workflows
 - Command history optimization and plugin support
 
-## Customization
-
-### Adding New Tools
-
-Edit the OS-specific installer(s):
-
-- On macOS: update `os/macos/install.sh` (add to the `tools` list or `apps` list)
-- On Linux: update `os/linux/install.sh` (check `install_cli_tools` function)
-
-### Modifying Dotfiles
-
-All dotfiles are located in the `dotfiles/` directory:
-
-- `dotfiles/.vimrc` - Vim configuration
-- `dotfiles/.tmux.conf` - Tmux configuration
-- `dotfiles/.zshrc` - Zsh configuration
-- `dotfiles/.gitconfig` - Git configuration
-- `dotfiles/functions.sh` - Shared utility functions
-- `dotfiles/aliases.sh` - Shared aliases
-
-After modifying, re-run the installer or create symlinks manually:
-
-```bash
-ln -sf ~/.dotfiles/dotfiles/.vimrc ~/.vimrc
-```
-
-### Adding OS Support
-
-To add support for other operating systems:
-
-1. Create a new directory: `os/[osname]/`
-2. Add an `install.sh` script following existing examples
-3. The main installer will automatically detect and use it
-
-Example structure:
-
-```text
-os/
-├── macos/
-│   ├── install.sh
-└── linux/
-    ├── install.sh
-```
+For customization instructions and contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Testing Your Installation
 
@@ -247,14 +205,6 @@ After running the installer, verify with the comprehensive test script:
 - ✅ **File Permissions** - Ensures scripts are executable
 
 The test script provides detailed output showing which components passed or failed, making it easy to identify any issues with your installation.
-
-## Contributing
-
-Feel free to submit issues and enhancement requests! This dotfiles setup is designed to be:
-
-- **Modular** - Easy to add/remove components
-- **Cross-platform** - Built for easy OS support addition
-- **Configurable** - Simple to customize for personal preferences
 
 ## License
 


### PR DESCRIPTION
## Summary
- move customization and contributing guidance into new `CONTRIBUTING.md`
- reference the dedicated file from `README`

## Testing
- `bash test_install.sh` *(fails: brew, vim, tmux, zsh, eza, pre-commit, btop, nmap, htop, ipython3, helm, speedtest-cli, fzf, delta, docker, tshark, act; missing config files)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ebe7d0388332a99737731ecfcc7b