### PR TITLE
Add Paintbrush to macOS app setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A comprehensive dotfiles setup for macOS and Linux (Ubuntu/Debian-based; include
 - **Docker Desktop** - Container development platform
 - **Wireshark** - Network protocol analyzer
 - **Postman** - API development and testing tool
+- **Paintbrush** - Simple image editor
 - **Typora** - Markdown editor
 - **DBeaver Community** - Universal database management tool
 

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -101,6 +101,7 @@ install_applications() {
         "Docker:docker"
         "Wireshark:wireshark-app"
         "Postman:postman"
+        "Paintbrush:paintbrush"
         "Typora:typora"
         "DBeaver:dbeaver-community"
         "GitKraken:gitkraken"

--- a/test_install.sh
+++ b/test_install.sh
@@ -127,6 +127,7 @@ test_apps() {
         "Docker"
         "Wireshark"
         "Postman"
+        "Paintbrush"
         "Typora"
         "DBeaver"
         "GitKraken"


### PR DESCRIPTION
## Summary
- include Paintbrush in macOS GUI application installs
- document Paintbrush in README
- test for Paintbrush presence in macOS installation tests

## Testing
- `bash test_install.sh --no-homebrew --no-apps` *(fails: missing CLI tools in container)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f4cead208332afab3a66e8060787