### PR TITLE
Install net-tools on Linux

### DIFF
--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -35,7 +35,7 @@ apt_update_and_basics() {
     # Common basics
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
         build-essential curl wget ca-certificates gnupg lsb-release software-properties-common \
-        git unzip xz-utils pkg-config
+        git unzip xz-utils pkg-config net-tools
 }
 
 install_cli_tools_with_apt() {

--- a/test_install.sh
+++ b/test_install.sh
@@ -97,6 +97,7 @@ test_cli_tools_exists() {
         "fzf installation:fzf"
         "delta installation:delta"
         "Java (openjdk) installation:java"
+        "net-tools installation:ifconfig"
         "watch installation:watch"
         "docker CLI command:docker"
         "tshark CLI command (Wireshark):tshark"


### PR DESCRIPTION
## Summary
- include net-tools in the Linux base packages
- test for net-tools presence via ifconfig

## Testing
- `./test_install.sh --no-apps --no-homebrew`

------
https://chatgpt.com/codex/tasks/task_e_68ab4c86baf08332bb0b1bc7d6bcf9e5