### PR TITLE
feat: install poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A comprehensive dotfiles setup for macOS and Linux (Ubuntu/Debian-based; include
 - **ruff** - Fast Python linter
 - **uv** - Ultra-fast Python package installer
 - **pre-commit** - Git hooks framework
+- **poetry** - Python dependency management
 - **pyenv** - Python version management
 - **btop** - Modern system monitor (alternative to htop)
 - **nmap** - Network discovery and security auditing utility

--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -141,6 +141,21 @@ try_install_pre_commit() {
     fi
 }
 
+try_install_poetry() {
+    local tool_name="poetry"
+    if ! command -v poetry >/dev/null 2>&1; then
+        log_install $tool_name
+        if ! curl -sSL https://install.python-poetry.org | python3 -; then
+            log_error "Failed to install $tool_name"
+            FAILED_INSTALLATIONS+=("$tool_name")
+        else
+            log_success "$tool_name installed successfully"
+        fi
+    else
+        log_found "$tool_name is already installed ($(poetry --version 2>/dev/null || echo version unknown))"
+    fi
+}
+
 install_cli_tools() {
     log_info "Installing command-line tools..."
 
@@ -153,6 +168,7 @@ install_cli_tools() {
     try_install_helm
     try_install_act
     try_install_pre_commit
+    try_install_poetry
 }
 
 install_pyenv() {

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -68,6 +68,7 @@ install_cli_tools() {
         "Zsh:zsh:zsh --version:zsh"
         "ruff:ruff:ruff --version:ruff"
         "pre-commit:pre-commit:pre-commit --version:pre-commit"
+        "Poetry:poetry:poetry --version:poetry"
         "btop:btop:btop --version:btop"
         "nmap:nmap:nmap --version:nmap"
         "htop:htop:htop --version:htop"

--- a/test_install.sh
+++ b/test_install.sh
@@ -87,6 +87,7 @@ test_cli_tools_exists() {
         "eza installation:eza"
         "ruff installation:ruff"
         "pre-commit installation:pre-commit"
+        "poetry installation:poetry"
         "btop installation:btop"
         "nmap installation:nmap"
         "htop installation:htop"


### PR DESCRIPTION
## Summary
- install Poetry on Linux via official installer
- install Poetry with Homebrew on macOS
- document Poetry in README and tests

## Testing
- `bash test_install.sh --no-apps --no-homebrew` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a9579f7883329944740609461e09