### PR TITLE
Include GitHub CLI in installers

### DIFF
--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -58,6 +58,7 @@ install_cli_tools_with_apt() {
         "Speedtest CLI:speedtest-cli:speedtest-cli --version:speedtest-cli"
         "Java JDK:javac:javac -version:default-jdk"
         "TShark:tshark:tshark --version:tshark"
+        "GitHub CLI:gh:gh --version:gh"
     )
     install_tools_with_package_manager "apt" "apt" \
     "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y" tools

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -79,6 +79,7 @@ install_cli_tools() {
         "fzf:fzf:fzf --version:fzf"
         "delta:delta:delta --version:git-delta"
         "act:act:act --version:act"
+        "GitHub CLI:gh:gh --version:gh"
     )
     install_tools_with_package_manager "Homebrew" "brew" "brew install" tools
     

--- a/test_install.sh
+++ b/test_install.sh
@@ -105,6 +105,7 @@ test_cli_tools_exists() {
         "pip installation:pip3"
         "Java installation:javac"
         "act installation:act"
+        "GitHub CLI installation:gh"
     )
 
     for entry in "${tools[@]}"; do
@@ -258,13 +259,15 @@ main() {
     run_test "Node.js can execute JavaScript" "node -e 'console.log(\"test\")' >/dev/null 2>&1"
     
     run_test "Rust compiler responds to version check" "rustc --version >/dev/null 2>&1"
-    
+
     run_test "fzf can show version" "fzf --version >/dev/null 2>&1"
     run_test "fzf can list files" "echo | fzf --filter='' >/dev/null 2>&1 || true"
-    
+
     run_test "delta can show version" "delta --version >/dev/null 2>&1"
     run_test "delta can process diff" "echo -e 'line1\nline2' | delta --color=never >/dev/null 2>&1 || true"
-    
+
+    run_test "GitHub CLI responds to version check" "gh --version >/dev/null 2>&1"
+
     show_tests_summary
 }
 


### PR DESCRIPTION
## Summary
- Install GitHub CLI via Homebrew on macOS
- Install GitHub CLI via apt on Linux
- Test GitHub CLI presence and version in post-install script

## Testing
- `bash test_install.sh --no-homebrew --no-apps` *(fails: fzf, delta, GitHub CLI missing, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b155c0090c8332a79e6df9d5e43d60