### PR TITLE
Install and initialize zoxide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A comprehensive dotfiles setup for macOS and Linux (Ubuntu/Debian-based; include
 - **htop** - Interactive process viewer
 - **ipython** - Enhanced interactive Python shell
 - **ripgrep** - Fast text search tool (rg command)
+- **zoxide** - Smart directory navigation with `z`
 - **fzf** - Command-line fuzzy finder
 - **delta** - Syntax-highlighting pager for git diffs
 - **watch** - Periodically run a command and display output
@@ -182,6 +183,7 @@ Linux only:
 - Oh My Zsh with Powerlevel10k theme for beautiful, informative prompt
 - Enhanced ls commands using `eza`
 - Enhanced cat using `bat`
+- Smart directory switching with `zoxide`
 - Comprehensive git aliases and development shortcuts
 - Modular utilities system that automatically loads all `.sh` files from `~/.config/shell-utils/`
 - Useful functions for productivity and development workflows

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -95,6 +95,8 @@ plugins=(
 
 source $ZSH/oh-my-zsh.sh
 
+eval "$(zoxide init zsh)"
+
 # User configuration
 
 # export MANPATH="/usr/local/man:$MANPATH"

--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -54,6 +54,7 @@ install_cli_tools_with_apt() {
         "nmap:nmap:nmap --version:nmap"
         "ripgrep:rg:rg --version:ripgrep"
         "IPython3:ipython3:ipython3 --version:ipython3"
+        "zoxide:zoxide:zoxide --version:zoxide"
         "fzf:fzf:fzf --version:fzf"
         "Speedtest CLI:speedtest-cli:speedtest-cli --version:speedtest-cli"
         "Java JDK:javac:javac -version:default-jdk"

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -77,6 +77,7 @@ install_cli_tools() {
         "Helm:helm:helm version --short:helm"
         "speedtest-cli:speedtest-cli:speedtest-cli --version:speedtest-cli"
         "fzf:fzf:fzf --version:fzf"
+        "zoxide:zoxide:zoxide --version:zoxide"
         "delta:delta:delta --version:git-delta"
         "act:act:act --version:act"
     )

--- a/test_install.sh
+++ b/test_install.sh
@@ -93,6 +93,7 @@ test_cli_tools_exists() {
         "htop installation:htop"
         "IPython installation:ipython3"
         "ripgrep installation:rg"
+        "zoxide installation:zoxide"
         "helm installation:helm"
         "speedtest-cli installation:speedtest-cli"
         "fzf installation:fzf"


### PR DESCRIPTION
## Summary
- install zoxide in macOS and Linux installers
- initialize zoxide in `.zshrc`
- document zoxide usage and test for it

## Testing
- `bash ./test_install.sh --no-apps --no-homebrew` *(fails: fzf, delta, and many others missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b15605524c83328e6428af189185e4