### PR TITLE
add kubectl installation

### DIFF
--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -156,6 +156,24 @@ try_install_poetry() {
     fi
 }
 
+try_install_kubectl () {
+    local tool_name="kubectl"
+    if ! command -v kubectl >/dev/null 2>&1; then
+        log_install $tool_name
+        if curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+            && sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
+            && kubectl version --client >/dev/null 2>&1; then
+            log_success "$tool_name installed successfully"
+        else
+            log_error "Failed to install $tool_name"
+            FAILED_INSTALLATIONS+=("$tool_name")
+        fi
+        rm -f kubectl
+    else
+        log_found "$tool_name is already installed ($(kubectl version --client 2>/dev/null || echo version unknown))"
+    fi
+}
+
 install_cli_tools() {
     log_info "Installing command-line tools..."
 
@@ -169,6 +187,7 @@ install_cli_tools() {
     try_install_act
     try_install_pre_commit
     try_install_poetry
+    try_install_kubectl
 }
 
 install_pyenv() {

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -75,13 +75,14 @@ install_cli_tools() {
         "IPython:ipython:ipython --version:ipython"
         "ripgrep:rg:rg --version:ripgrep"
         "Helm:helm:helm version --short:helm"
+        "kubectl:kubectl:kubectl version --client:kubernetes-cli"
         "speedtest-cli:speedtest-cli:speedtest-cli --version:speedtest-cli"
         "fzf:fzf:fzf --version:fzf"
         "delta:delta:delta --version:git-delta"
         "act:act:act --version:act"
     )
     install_tools_with_package_manager "Homebrew" "brew" "brew install" tools
-    
+
     try_install_uv
 }
 


### PR DESCRIPTION
## Summary
- install kubectl via Homebrew on macOS by adding to CLI tools list
- install kubectl on Linux from official binaries with a helper function
- verify kubectl installation in both scripts

## Testing
- `bash -n os/macos/install.sh os/linux/install.sh`
- `bash test_install.sh --no-apps --no-homebrew` *(fails: numerous tools missing; vim, tmux, zsh, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b155c8e5988332be48616a95aaea75