### PR TITLE
Symlink shell utility scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ A comprehensive dotfiles setup for macOS and Linux (Ubuntu/Debian-based; include
 The dotfiles include a modular utilities system located at `~/.config/shell-utils/`:
 
 - **`functions.sh`** - Essential functions like `extract()`, `mkcd()`, and beautiful logging functions
+- **`aliases.sh`** - Cross-shell aliases for everyday commands
 - **Extensible** - Add your own `.sh` files to the directory and they'll be automatically loaded
 
 **Key utilities include:**

--- a/test_install.sh
+++ b/test_install.sh
@@ -170,7 +170,10 @@ test_dotfiles() {
     echo ""
 
     run_test "Modular shell utilities system is configured" "grep -q '.config/shell-utils' '$HOME/.zshrc'"
-    run_test "Shell utilities are installed" "test -f '$HOME/.config/shell-utils/functions.sh'"
+    run_test "functions.sh symlink exists" "test_symlink_exists '$HOME/.config/shell-utils/functions.sh'"
+    run_test "functions.sh target exists" "test_symlink_target_exists '$HOME/.config/shell-utils/functions.sh'"
+    run_test "aliases.sh symlink exists" "test_symlink_exists '$HOME/.config/shell-utils/aliases.sh'"
+    run_test "aliases.sh target exists" "test_symlink_target_exists '$HOME/.config/shell-utils/aliases.sh'"
     echo ""
 }
 

--- a/utils.sh
+++ b/utils.sh
@@ -198,19 +198,23 @@ setup_dotfiles() {
     done
     
     log_info "Setting up modular shell utilities..."
-    if [[ -f "$DOTFILES_ROOT/dotfiles/functions.sh" ]]; then
-        cp "$DOTFILES_ROOT/dotfiles/functions.sh" "$HOME/.config/shell-utils/functions.sh"
-        log_success "Shell utilities installed to ~/.config/shell-utils/"
-    else
-        log_warning "functions.sh not found - skipping utilities setup"
-    fi
-    if [[ -f "$DOTFILES_ROOT/dotfiles/aliases.sh" ]]; then
-        cp "$DOTFILES_ROOT/dotfiles/aliases.sh" "$HOME/.config/shell-utils/aliases.sh"
-        log_success "Aliases installed to ~/.config/shell-utils/"
-    else
-        log_warning "aliases.sh not found - skipping aliases setup"
-    fi
-    
+    local utils=("functions.sh" "aliases.sh")
+    for util in "${utils[@]}"; do
+        local source_file="$DOTFILES_ROOT/dotfiles/$util"
+        local target_file="$HOME/.config/shell-utils/$util"
+
+        if [[ -f "$source_file" ]]; then
+            if [[ -e "$target_file" ]]; then
+                log_warning "Backing up existing $(basename "$target_file") to $(basename "$target_file").backup"
+                mv "$target_file" "$target_file.backup"
+            fi
+            ln -sf "$source_file" "$target_file"
+            log_success "$util symlinked to ~/.config/shell-utils/"
+        else
+            log_warning "$util not found - skipping"
+        fi
+    done
+
     log_info "You can now add more utility files to ~/.config/shell-utils/ and they will be automatically loaded"
 }
 


### PR DESCRIPTION
## Summary
- Symlink `functions.sh` and `aliases.sh` into `~/.config/shell-utils` rather than copying
- Verify symlinks in installation tests and document `aliases.sh` utility

## Testing
- `bash -n utils.sh test_install.sh install.sh`
- `bash test_install.sh --no-homebrew --no-apps` *(fails: command not found, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b1872a5f208332b0d3d59975b36321