### PR TITLE
feat: add fd tool installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A comprehensive dotfiles setup for macOS and Linux (Ubuntu/Debian-based; include
 - **htop** - Interactive process viewer
 - **ipython** - Enhanced interactive Python shell
 - **ripgrep** - Fast text search tool (rg command)
+- **fd** - Simple, fast and user-friendly alternative to `find`
 - **zoxide** - Smart directory navigation with `z`
 - **fzf** - Command-line fuzzy finder
 - **delta** - Syntax-highlighting pager for git diffs

--- a/dotfiles/aliases.sh
+++ b/dotfiles/aliases.sh
@@ -18,4 +18,5 @@ alias sso="aws sso login"
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     alias open='xdg-open'
     alias bat="batcat"
+    alias fd="fdfind"
 fi

--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -53,6 +53,7 @@ install_cli_tools_with_apt() {
         "htop:htop:htop --version:htop"
         "nmap:nmap:nmap --version:nmap"
         "ripgrep:rg:rg --version:ripgrep"
+        "fd (fd-find):fdfind:fdfind --version:fd-find"
         "IPython3:ipython3:ipython3 --version:ipython3"
         "zoxide:zoxide:zoxide --version:zoxide"
         "fzf:fzf:fzf --version:fzf"

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -74,6 +74,7 @@ install_cli_tools() {
         "htop:htop:htop --version:htop"
         "IPython:ipython:ipython --version:ipython"
         "ripgrep:rg:rg --version:ripgrep"
+        "fd:fd:fd --version:fd"
         "Helm:helm:helm version --short:helm"
         "speedtest-cli:speedtest-cli:speedtest-cli --version:speedtest-cli"
         "fzf:fzf:fzf --version:fzf"

--- a/test_install.sh
+++ b/test_install.sh
@@ -93,6 +93,7 @@ test_cli_tools_exists() {
         "htop installation:htop"
         "IPython installation:ipython3"
         "ripgrep installation:rg"
+        "fd installation:fd"
         "zoxide installation:zoxide"
         "helm installation:helm"
         "speedtest-cli installation:speedtest-cli"


### PR DESCRIPTION
## Summary
- install the `fd` search utility on macOS and Linux
- map `fd` to `fdfind` on Linux via shell alias instead of a symlink
- cover `fd` in documentation and test script

## Testing
- `bash test_install.sh --no-apps --no-homebrew` *(fails: Tests failed: 42)*

------
https://chatgpt.com/codex/tasks/task_e_68b188eb4ea0833298be40f312bff621