### PR TITLE
[SCRUM-6] Feature: Claude Code installation for Mac and Linux

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -15,6 +15,10 @@ fi
 if [ -d "$HOME/bin" ] && [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
   export PATH="$HOME/bin:$PATH"
 fi
+# Claude Code CLI (installed to ~/.claude/bin)
+if [ -d "$HOME/.claude/bin" ] && [[ ":$PATH:" != *":$HOME/.claude/bin:"* ]]; then
+  export PATH="$HOME/.claude/bin:$PATH"
+fi
 
 # Path to your Oh My Zsh installation.
 export ZSH="$HOME/.oh-my-zsh"

--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -192,6 +192,7 @@ install_cli_tools() {
     try_install_pre_commit
     try_install_poetry
     try_install_kubectl
+    try_install_claude_code
 }
 
 install_pyenv() {

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -88,6 +88,7 @@ install_cli_tools() {
     install_tools_with_package_manager "Homebrew" "brew" "brew install" tools
 
     try_install_uv
+    try_install_claude_code
 }
 
 install_applications() {

--- a/test_install.sh
+++ b/test_install.sh
@@ -12,7 +12,7 @@ source "$SCRIPT_DIR/dotfiles/functions.sh"
 source "$SCRIPT_DIR/dotfiles/aliases.sh"
 
 # Ensure typical user tool paths are available in this test session
-export PATH="$PATH:$HOME/.cargo/bin:$HOME/.pyenv/bin:/usr/bin:/usr/local/bin:$HOME/.local/bin:$HOME/bin"
+export PATH="$PATH:$HOME/.cargo/bin:$HOME/.pyenv/bin:/usr/bin:/usr/local/bin:$HOME/.local/bin:$HOME/bin:$HOME/.claude/bin"
 
 # Test results tracking
 TESTS_PASSED=0
@@ -110,6 +110,7 @@ test_cli_tools_exists() {
         "Java installation:javac"
         "act installation:act"
         "GitHub CLI installation:gh"
+        "Claude Code installation:claude"
     )
 
     for entry in "${tools[@]}"; do

--- a/utils.sh
+++ b/utils.sh
@@ -308,6 +308,26 @@ try_install_uv() {
     fi
 }
 
+# Dedicated function for installing Claude Code (curl pipe pattern)
+try_install_claude_code() {
+    local tool_name="Claude Code"
+    if ! command -v claude > /dev/null 2>&1; then
+        log_install "$tool_name"
+        if ! curl -fsSL https://claude.ai/install.sh | bash; then
+            log_error "Failed to install $tool_name"
+            FAILED_INSTALLATIONS+=("$tool_name")
+        else
+            # Source the PATH update for current session
+            if [ -d "$HOME/.claude/bin" ]; then
+                export PATH="$HOME/.claude/bin:$PATH"
+            fi
+            log_success "$tool_name installed successfully"
+        fi
+    else
+        log_found "$tool_name is already installed ($(claude --version 2> /dev/null || echo version unknown))"
+    fi
+}
+
 try_install_python() {
     local python_version=$1
     local tool_name="Python $python_version"


### PR DESCRIPTION
## Summary

This PR integrates Claude Code CLI installation into the dotfiles project for both macOS and Linux environments, enabling automated setup of the AI-powered CLI agent as part of the standard development environment provisioning.

## Changes

- **utils.sh**: Added `try_install_claude_code()` function that uses the official installer (`curl -fsSL https://claude.ai/install.sh | bash`) with idempotency checks and failure tracking
- **os/macos/install.sh**: Integrated Claude Code installation into the CLI tools installation stage
- **os/linux/install.sh**: Integrated Claude Code installation into the CLI tools installation stage
- **dotfiles/.zshrc**: Added conditional PATH export for `~/.claude/bin` following existing patterns
- **test_install.sh**: Added Claude Code to the CLI tools verification suite and updated PATH for test session

## Testing

- [ ] Run `./install.sh -y` on a fresh macOS machine
- [ ] Run `./install.sh -y` on a fresh Linux machine
- [ ] Verify `claude --version` works after installation
- [ ] Re-run installation to confirm idempotency (should show "already installed")
- [ ] Run `./test_install.sh` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)