### PR TITLE
[SCRUM-6] Feature: Claude Code installation for Mac and Linux

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -142,6 +142,11 @@ export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
 
+# Claude Code CLI setup
+if [ -d "$HOME/.claude/bin" ] && [[ ":$PATH:" != *":$HOME/.claude/bin:"* ]]; then
+    export PATH="$HOME/.claude/bin:$PATH"
+fi
+
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 

--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -192,6 +192,7 @@ install_cli_tools() {
     try_install_pre_commit
     try_install_poetry
     try_install_kubectl
+    try_install_claude_code
 }
 
 install_pyenv() {

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -88,6 +88,7 @@ install_cli_tools() {
     install_tools_with_package_manager "Homebrew" "brew" "brew install" tools
 
     try_install_uv
+    try_install_claude_code
 }
 
 install_applications() {

--- a/utils.sh
+++ b/utils.sh
@@ -308,6 +308,27 @@ try_install_uv() {
     fi
 }
 
+# Install Claude Code AI assistant CLI
+# Uses the official installer script which handles PATH setup
+try_install_claude_code() {
+    local tool_name="Claude Code"
+    if ! command -v claude > /dev/null 2>&1; then
+        log_install "$tool_name"
+        if ! curl -fsSL https://claude.ai/install.sh | bash; then
+            log_error "Failed to install $tool_name"
+            FAILED_INSTALLATIONS+=("$tool_name")
+        else
+            # Source the updated PATH if the installer added it
+            if [[ -f "$HOME/.claude/bin/claude" ]]; then
+                export PATH="$HOME/.claude/bin:$PATH"
+            fi
+            log_success "$tool_name installed successfully"
+        fi
+    else
+        log_found "$tool_name is already installed ($(claude --version 2> /dev/null || echo version unknown))"
+    fi
+}
+
 try_install_python() {
     local python_version=$1
     local tool_name="Python $python_version"


### PR DESCRIPTION
## Summary

Integrates Claude Code CLI installation into the dotfiles project for both macOS and Linux environments, enabling automated setup of the AI coding assistant as part of the standard development environment provisioning.

## Changes

- Add `try_install_claude_code()` shared function in `utils.sh` that uses the official installer (`curl -fsSL https://claude.ai/install.sh | bash`)
- Add Claude Code installation to macOS CLI tools stage in `os/macos/install.sh`
- Add Claude Code installation to Linux CLI tools stage in `os/linux/install.sh`
- Add `~/.claude/bin` PATH export to `dotfiles/.zshrc` with idempotent check to prevent duplicate entries

## Testing

- [ ] Run `./install.sh` on macOS and verify Claude Code installs successfully
- [ ] Run `./install.sh` on Linux/WSL and verify Claude Code installs successfully
- [ ] Re-run installer and verify "already installed" message appears (no redundant installation)
- [ ] Open new terminal and verify `claude` command is accessible
- [ ] Run with `-y` flag to verify non-interactive mode works

[SCRUM-6](https://bengabay38.atlassian.net/browse/SCRUM-6)

[SCRUM-6]: https://bengabay38.atlassian.net/browse/SCRUM-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ