### PR TITLE
Add ShellCheck to macOS/Linux installers, tests, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A comprehensive dotfiles setup for macOS and Linux (Ubuntu/Debian-based; include
 - **ipython** - Enhanced interactive Python shell
 - **ripgrep** - Fast text search tool (rg command)
 - **fd** - Simple, fast and user-friendly alternative to `find`
+- **ShellCheck** - Shell script static analysis tool
 - **zoxide** - Smart directory navigation with `z`
 - **fzf** - Command-line fuzzy finder
 - **delta** - Syntax-highlighting pager for git diffs

--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -54,6 +54,7 @@ install_cli_tools_with_apt() {
         "nmap:nmap:nmap --version:nmap"
         "ripgrep:rg:rg --version:ripgrep"
         "fd (fd-find):fdfind:fdfind --version:fd-find"
+        "ShellCheck:shellcheck:shellcheck --version:shellcheck"
         "IPython3:ipython3:ipython3 --version:ipython3"
         "zoxide:zoxide:zoxide --version:zoxide"
         "fzf:fzf:fzf --version:fzf"

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -76,6 +76,7 @@ install_cli_tools() {
         "IPython:ipython:ipython --version:ipython"
         "ripgrep:rg:rg --version:ripgrep"
         "fd:fd:fd --version:fd"
+        "ShellCheck:shellcheck:shellcheck --version:shellcheck"
         "Helm:helm:helm version --short:helm"
         "kubectl:kubectl:kubectl version --client:kubernetes-cli"
         "speedtest-cli:speedtest-cli:speedtest-cli --version:speedtest-cli"

--- a/test_install.sh
+++ b/test_install.sh
@@ -96,6 +96,7 @@ test_cli_tools_exists() {
         "IPython installation:ipython3"
         "ripgrep installation:rg"
         "fd installation:fd"
+        "ShellCheck installation:shellcheck"
         "zoxide installation:zoxide"
         "helm installation:helm"
         "speedtest-cli installation:speedtest-cli"


### PR DESCRIPTION
### Motivation
- Include `shellcheck` in the standard toolset so shell scripts can be installed on both macOS and Linux and verified by the install/test tooling.

### Description
- Added `ShellCheck` to the CLI tools lists in `os/macos/install.sh` and `os/linux/install.sh`, added a presence check in `test_install.sh`, and documented it in `README.md`.

### Testing
- Ran a syntax validation with `bash -n os/macos/install.sh os/linux/install.sh test_install.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ecb9fcc48332ae18603187da32ae)