### PR TITLE
Add jq to macOS/Linux installers, tests, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A comprehensive dotfiles setup for macOS and Linux (Ubuntu/Debian-based; include
 - **htop** - Interactive process viewer
 - **ipython** - Enhanced interactive Python shell
 - **ripgrep** - Fast text search tool (rg command)
+- **jq** - Command-line JSON processor
 - **fd** - Simple, fast and user-friendly alternative to `find`
 - **zoxide** - Smart directory navigation with `z`
 - **fzf** - Command-line fuzzy finder

--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -53,6 +53,7 @@ install_cli_tools_with_apt() {
         "htop:htop:htop --version:htop"
         "nmap:nmap:nmap --version:nmap"
         "ripgrep:rg:rg --version:ripgrep"
+        "jq:jq:jq --version:jq"
         "fd (fd-find):fdfind:fdfind --version:fd-find"
         "IPython3:ipython3:ipython3 --version:ipython3"
         "zoxide:zoxide:zoxide --version:zoxide"

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -75,6 +75,7 @@ install_cli_tools() {
         "htop:htop:htop --version:htop"
         "IPython:ipython:ipython --version:ipython"
         "ripgrep:rg:rg --version:ripgrep"
+        "jq:jq:jq --version:jq"
         "fd:fd:fd --version:fd"
         "Helm:helm:helm version --short:helm"
         "kubectl:kubectl:kubectl version --client:kubernetes-cli"

--- a/test_install.sh
+++ b/test_install.sh
@@ -95,6 +95,7 @@ test_cli_tools_exists() {
         "htop installation:htop"
         "IPython installation:ipython3"
         "ripgrep installation:rg"
+        "jq installation:jq"
         "fd installation:fd"
         "zoxide installation:zoxide"
         "helm installation:helm"


### PR DESCRIPTION
### Motivation
- Ensure the `jq` JSON processor is installed and verified on both macOS and Linux installations and is documented in the project README.

### Description
- Added `jq` to `os/macos/install.sh` and `os/linux/install.sh`, added a `jq` presence check in `test_install.sh`, and documented `jq` in `README.md`.

### Testing
- Verified script syntax with `bash -n os/linux/install.sh`, `bash -n os/macos/install.sh`, and `bash -n test_install.sh`, and confirmed the changes with `rg -n "jq" os/linux/install.sh os/macos/install.sh test_install.sh README.md`, all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ecd772d08332ba4c3f14791ab32f)