### PR TITLE
Add direnv to macOS/Linux installs, tests, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A comprehensive dotfiles setup for macOS and Linux (Ubuntu/Debian-based; include
 - **ripgrep** - Fast text search tool (rg command)
 - **fd** - Simple, fast and user-friendly alternative to `find`
 - **zoxide** - Smart directory navigation with `z`
+- **direnv** - Automatic environment variable loading per project
 - **fzf** - Command-line fuzzy finder
 - **delta** - Syntax-highlighting pager for git diffs
 - **watch** - Periodically run a command and display output

--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -56,6 +56,7 @@ install_cli_tools_with_apt() {
         "fd (fd-find):fdfind:fdfind --version:fd-find"
         "IPython3:ipython3:ipython3 --version:ipython3"
         "zoxide:zoxide:zoxide --version:zoxide"
+        "direnv:direnv:direnv version:direnv"
         "fzf:fzf:fzf --version:fzf"
         "Speedtest CLI:speedtest-cli:speedtest-cli --version:speedtest-cli"
         "Java JDK:javac:javac -version:default-jdk"

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -81,6 +81,7 @@ install_cli_tools() {
         "speedtest-cli:speedtest-cli:speedtest-cli --version:speedtest-cli"
         "fzf:fzf:fzf --version:fzf"
         "zoxide:zoxide:zoxide --version:zoxide"
+        "direnv:direnv:direnv version:direnv"
         "delta:delta:delta --version:git-delta"
         "act:act:act --version:act"
         "GitHub CLI:gh:gh --version:gh"

--- a/test_install.sh
+++ b/test_install.sh
@@ -97,6 +97,7 @@ test_cli_tools_exists() {
         "ripgrep installation:rg"
         "fd installation:fd"
         "zoxide installation:zoxide"
+        "direnv installation:direnv"
         "helm installation:helm"
         "speedtest-cli installation:speedtest-cli"
         "fzf installation:fzf"


### PR DESCRIPTION
### Motivation
- Ensure `direnv` is installed and verified across platforms and documented alongside other developer CLI tools.

### Description
- Add `direnv` to the Homebrew CLI install list in `os/macos/install.sh` so macOS installs include it.
- Add `direnv` to the apt CLI install list in `os/linux/install.sh` so Linux installs include it.
- Add a `direnv` presence check to `test_install.sh` so the test suite will verify the tool is installed.
- Document `direnv` in the README command-line tools list in `README.md`.

### Testing
- Verified shell syntax with `bash -n os/macos/install.sh os/linux/install.sh test_install.sh`, which completed successfully.
- No other automated runtime tests were executed in this change set; the `test_install.sh` update enables future verification of `direnv`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ece6c074833297b6abb16b7b82d9)