### PR TITLE
Add tldr to Linux/macOS installs, tests, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A comprehensive dotfiles setup for macOS and Linux (Ubuntu/Debian-based; include
 - **fd** - Simple, fast and user-friendly alternative to `find`
 - **zoxide** - Smart directory navigation with `z`
 - **fzf** - Command-line fuzzy finder
+- **tldr** - Simplified community-driven man pages
 - **delta** - Syntax-highlighting pager for git diffs
 - **watch** - Periodically run a command and display output
 - **helm** - Kubernetes package manager

--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -57,6 +57,7 @@ install_cli_tools_with_apt() {
         "IPython3:ipython3:ipython3 --version:ipython3"
         "zoxide:zoxide:zoxide --version:zoxide"
         "fzf:fzf:fzf --version:fzf"
+        "tldr:tldr:tldr --version:tldr"
         "Speedtest CLI:speedtest-cli:speedtest-cli --version:speedtest-cli"
         "Java JDK:javac:javac -version:default-jdk"
         "TShark:tshark:tshark --version:tshark"

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -80,6 +80,7 @@ install_cli_tools() {
         "kubectl:kubectl:kubectl version --client:kubernetes-cli"
         "speedtest-cli:speedtest-cli:speedtest-cli --version:speedtest-cli"
         "fzf:fzf:fzf --version:fzf"
+        "tldr:tldr:tldr --version:tldr"
         "zoxide:zoxide:zoxide --version:zoxide"
         "delta:delta:delta --version:git-delta"
         "act:act:act --version:act"

--- a/test_install.sh
+++ b/test_install.sh
@@ -100,6 +100,7 @@ test_cli_tools_exists() {
         "helm installation:helm"
         "speedtest-cli installation:speedtest-cli"
         "fzf installation:fzf"
+        "tldr installation:tldr"
         "delta installation:delta"
         "Java (openjdk) installation:java"
         "net-tools installation:ifconfig"


### PR DESCRIPTION
### Motivation
- Ensure `tldr` (community-driven simplified man pages) is installed by default on both macOS and Linux installation flows. 
- Include `tldr` in the post-install verification to catch missing installs during CI or local checks. 
- Document `tldr` in the README so the tool list matches the installer behavior.

### Description
- Added `tldr` to the macOS Homebrew CLI tools list in `os/macos/install.sh`.
- Added `tldr` to the Linux apt CLI tools list in `os/linux/install.sh`.
- Added a `tldr` existence check to `test_install.sh` so the test suite verifies the command is available.
- Documented `tldr` in the README command-line tools section (`README.md`).

### Testing
- Ran a syntax check with `bash -n os/macos/install.sh os/linux/install.sh test_install.sh` which succeeded.
- Verified occurrences with `rg -n "tldr" os/macos/install.sh os/linux/install.sh test_install.sh README.md` which returned the expected matches.
- No automated test failures were reported after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9eda005208332aa690984697b6095)