### PR TITLE
Add kubectx to macOS/Linux installers, tests, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A comprehensive dotfiles setup for macOS and Linux (Ubuntu/Debian-based; include
 - **delta** - Syntax-highlighting pager for git diffs
 - **watch** - Periodically run a command and display output
 - **helm** - Kubernetes package manager
+- **kubectx** - Quickly switch between Kubernetes contexts and namespaces
 - **speedtest-cli** - Command-line internet speed test tool
 
 ### 📱 Applications (macOS)

--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -61,6 +61,7 @@ install_cli_tools_with_apt() {
         "Java JDK:javac:javac -version:default-jdk"
         "TShark:tshark:tshark --version:tshark"
         "GitHub CLI:gh:gh --version:gh"
+        "kubectx:kubectx:kubectx --help:kubectx"
     )
     install_tools_with_package_manager "apt" "apt" \
         "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y" tools

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -78,6 +78,7 @@ install_cli_tools() {
         "fd:fd:fd --version:fd"
         "Helm:helm:helm version --short:helm"
         "kubectl:kubectl:kubectl version --client:kubernetes-cli"
+        "kubectx:kubectx:kubectx -h:kubectx"
         "speedtest-cli:speedtest-cli:speedtest-cli --version:speedtest-cli"
         "fzf:fzf:fzf --version:fzf"
         "zoxide:zoxide:zoxide --version:zoxide"

--- a/test_install.sh
+++ b/test_install.sh
@@ -79,6 +79,7 @@ test_cli_tools_exists() {
         "yarn installation:yarn"
         "Prettier installation:prettier"
         "kubectl installation:kubectl"
+        "kubectx installation:kubectx"
         "Zsh installation:zsh"
         "Rust installation:rustc"
         "Cargo installation:cargo"


### PR DESCRIPTION
### Motivation
- Ensure `kubectx` is installed alongside other Kubernetes tooling so users can quickly switch contexts and namespaces on both macOS and Linux.
- Keep installer behavior and documentation consistent by verifying the tool is present after installation. 

### Description
- Added `kubectx` to the Homebrew CLI tools list in `os/macos/install.sh` so it will be installed on macOS. 
- Added `kubectx` to the apt-based CLI tools list in `os/linux/install.sh` so it will be installed on Debian/Ubuntu flows. 
- Extended `test_install.sh` to include a verification step for `kubectx` so the test suite checks for the binary. 
- Documented `kubectx` in `README.md` under the Command Line Tools list. 

### Testing
- Ran a syntax-only shell check with `bash -n os/macos/install.sh os/linux/install.sh test_install.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ee3cfb088332badd705ae7ac6e66)