### PR TITLE
Add neofetch to macOS/Linux installers, tests, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A comprehensive dotfiles setup for macOS and Linux (Ubuntu/Debian-based; include
 - **kubectx** - Quickly switch between Kubernetes contexts and namespaces
 - **speedtest-cli** - Command-line internet speed test tool
 - **AWS CLI** - Command-line interface for managing AWS services
+- **neofetch** - System information tool with terminal ASCII art
 
 ### 📱 Applications (macOS)
 

--- a/os/linux/install.sh
+++ b/os/linux/install.sh
@@ -67,6 +67,7 @@ install_cli_tools_with_apt() {
         "GitHub CLI:gh:gh --version:gh"
         "AWS CLI:aws:aws --version:awscli"
         "kubectx:kubectx:kubectx --help:kubectx"
+        "neofetch:neofetch:neofetch --version:neofetch"
     )
     install_tools_with_package_manager "apt" "apt" \
         "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y" tools

--- a/os/macos/install.sh
+++ b/os/macos/install.sh
@@ -93,6 +93,7 @@ install_cli_tools() {
         "GitHub CLI:gh:gh --version:gh"
         "AWS CLI:aws:aws --version:awscli"
         "starship:starship:starship --version:starship"
+        "neofetch:neofetch:neofetch --version:neofetch"
     )
     install_tools_with_package_manager "Homebrew" "brew" "brew install" tools
 

--- a/test_install.sh
+++ b/test_install.sh
@@ -119,6 +119,7 @@ test_cli_tools_exists() {
         "GitHub CLI installation:gh"
         "AWS CLI installation:aws"
         "starship installation:starship"
+        "neofetch installation:neofetch"
     )
 
     for entry in "${tools[@]}"; do


### PR DESCRIPTION
### Motivation
- Include `neofetch` in the standard toolset so the installer deploys a small system-info ASCII-art utility on both macOS and Debian/Ubuntu-based Linux systems.

### Description
- Added `neofetch` to the Homebrew install list in `os/macos/install.sh` so it is installed during the macOS CLI tools stage.
- Added `neofetch` to the apt install list in `os/linux/install.sh` so it is installed during the Linux CLI tools stage.
- Added a `neofetch` existence check to `test_install.sh` to validate the installation in the test suite.
- Documented `neofetch` in the CLI tools section of `README.md`.

### Testing
- Ran shell syntax checks with `bash -n` on `os/macos/install.sh`, `os/linux/install.sh`, and `test_install.sh`, which succeeded.
- Ran `./test_install.sh --help` to verify the test script runs and argument parsing paths, which succeeded.
- Verified the new `neofetch` entries are present using `rg` across `os/macos/install.sh`, `os/linux/install.sh`, `test_install.sh`, and `README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaa24ff7bc8332a9f39ba2295642e8)