### PR TITLE
chore(yazi): expand openers and add interactive open keybind

### DIFF
--- a/dotfiles/.config/yazi/keymap.toml
+++ b/dotfiles/.config/yazi/keymap.toml
@@ -1,4 +1,9 @@
 [[mgr.prepend_keymap]]
+on   = [ "<Enter>" ]
+run  = "open --interactive"
+desc = "Open with..."
+
+[[mgr.prepend_keymap]]
 on   = [ "c", "a", "a" ]
 run  = "plugin compress"
 desc = "Archive selected files"

--- a/dotfiles/.config/yazi/yazi.toml
+++ b/dotfiles/.config/yazi/yazi.toml
@@ -2,15 +2,51 @@
 show_hidden = true
 
 [opener]
-edit = [
-  { run = 'cursor "$@"', desc = "Open in Cursor", block = true },
+bat = [
+  { run = 'bat --paging=always "$@"', block = true, desc = "View with bat" },
+]
+vim = [
+  { run = 'vim "$@"', block = true, desc = "Edit with vim" },
+]
+code = [
+  { run = 'cursor "$@"', desc = "Open in Cursor", orphan = true },
+]
+pdf = [
+  { run = 'open "$@"', desc = "Open PDF", orphan = true },
+]
+image = [
+  { run = 'open "$@"', desc = "Open Image", orphan = true },
+]
+video = [
+  { run = 'open "$@"', desc = "Open Video", orphan = true },
+]
+archive = [
+  { run = 'open "$@"', desc = "Open Archive", orphan = true },
+]
+csv = [
+  { run = 'open "$@"', desc = "Open CSV", orphan = true },
+]
+pcap = [
+  { run = 'open "$@"', desc = "Open PCAP", orphan = true },
 ]
 
 [open]
 rules = [
-  { mime = "text/*", use = "edit" },
-  { mime = "application/json", use = "edit" },
-  { mime = "application/javascript", use = "edit" },
-  { mime = "application/x-shellscript", use = "edit" },
-  { name = "*.{ts,tsx,js,jsx,py,go,rs,c,cpp,h,hpp,java,kt,swift,php,rb,lua,vim,sh,bash,zsh,fish,conf,toml,yaml,yml,json,xml,html,css,scss,sass,md,txt}", use = "edit" },
+  # PCAP files
+  { mime = "application/tcpdump.pcap", use = "pcap" },
+  # CSV files
+  { url = "*.csv", use = "csv" },
+  # Archives
+  { mime = "application/zip", use = "archive" },
+  { mime = "application/x-tar", use = "archive" },
+  { mime = "application/gzip", use = "archive" },
+  { mime = "application/x-7z-compressed", use = "archive" },
+  # Images and videos
+  { mime = "image/*", use = "image" },
+  { mime = "video/*", use = "video" },
+  # PDF
+  { mime = "application/pdf", use = "pdf" },
+  # Text
+  { mime = "text/*", use = ["bat", "vim", "code"] },
+  { url = "*.{ts,tsx,js,jsx,py,go,rs,c,cpp,h,hpp,java,kt,swift,php,rb,lua,sh,bash,zsh,fish,conf,toml,yaml,yml,json,xml,html,css,scss,sass}", use = ["bat", "vim", "code"] },
 ]


### PR DESCRIPTION
Replaces the single edit opener with named openers per file type (bat, vim, code, pdf, image, video, archive, csv, pcap), updates open rules to match MIME types and file extensions accordingly, and adds an <Enter> keymap to trigger interactive file open selection.