### PR TITLE
chore(shell): add zsh history configuration

### DIFF
--- a/dotfiles/.shell-utils/history.sh
+++ b/dotfiles/.shell-utils/history.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env zsh
+# History configuration - based on https://medium.com/@n1zyy/zsh-history-made-simple-de3ec5c8f027
+
+export HISTSIZE=100000
+export SAVEHIST=100000
+
+# Critical: Share history across all sessions and append immediately
+# This prevents history loss when closing sessions
+setopt SHARE_HISTORY


### PR DESCRIPTION
Adds a dedicated history.sh utility to configure persistent and shared shell history across sessions, with a large history size limit (100k entries) and SHARE_HISTORY to prevent history loss when closing terminals.