### PR TITLE
chore(aliases): enable paging by default for bat

### DIFF
--- a/dotfiles/.shell-utils/aliases.sh
+++ b/dotfiles/.shell-utils/aliases.sh
@@ -5,6 +5,7 @@
 
 # Core
 alias cat="bat"
+alias bat="bat --paging=always"
 alias ls="eza --icons --hyperlink --sort=type"
 alias quit="exit"
 alias speedtest="speedtest-cli"


### PR DESCRIPTION
Sets bat --paging=always so bat always pages output, consistent with the enhanced cat experience.